### PR TITLE
Change deprecated `gvfs-set-attribute` to `gio set`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Microsoft Windows
 .. figure:: images/jupyter_cm_windows.png
    :alt: Jupyter context menu entries in windows
 
-   Jupyter context menu entries in windows
+   Jupyter context menu entries in windows.
 
 In addition to starting the QtConsole or the Jupyter Notebook server and
 launching the default browser, in Microsoft Windows the process runs
@@ -29,7 +29,7 @@ GNOME
 .. figure:: images/jupyter_cm_gnome.png
    :alt: Jupyter context menu entries in windows
 
-   Jupyter context menu entries in windows
+   Jupyter context menu entries in gnome.
 
 When selecting multiple folders, one instance of Jupyter
 QtConsole/notebook opens in each of the selected folders. Selecting a
@@ -40,6 +40,8 @@ Notebook 4.1 there is no way to shutdown the server from the notebook
 UI. To stop the server one has to manually kill the process.
 Alternatively, `nbmanager <https://github.com/takluyver/nbmanager>`__
 can discover all running servers and shut them down using via an UI.
+
+GNOME >= 2.22 is required.
 
 Installation instructions
 -------------------------

--- a/start_jupyter_cm/gnome.py
+++ b/start_jupyter_cm/gnome.py
@@ -26,7 +26,8 @@ for folder in folders:
 
 def add_jupyter_here():
     if not os.path.exists(NPATH):
-        print("Nothing done. Currently only Gnome and Windows are supported.")
+        print("Nothing done. Currently only Gnome with Nautilus as file ",
+              "manager is supported.")
         return
     if not os.path.exists(SPATH):
         os.makedirs(SPATH)
@@ -42,7 +43,7 @@ def add_jupyter_here():
                 f.write(script % (terminal, terminal))
             st = os.stat(script_path)
             os.chmod(script_path, st.st_mode | stat.S_IEXEC)
-            call(['gvfs-set-attribute', '-t', 'string', '%s' % script_path,
+            call(['gio', 'set', '-t', 'string', '%s' % script_path,
                   'metadata::custom-icon', 'file://%s' % logos[terminal]])
             print('Jupyter %s here created.' % terminal)
 


### PR DESCRIPTION
`gvfs-set-attribute` have been deprecated and it prevents setting the icons. Running the script reports the error below but the scripts are correctly installed (without the icons).

```
This tool has been deprecated, use 'gio set' instead.
See 'gio help set' for more info.

Jupyter qtconsole here created.
This tool has been deprecated, use 'gio set' instead.
See 'gio help set' for more info.

Jupyter notebook here created.
```
The message can mislead users to think that the scripts have not been installed correctly.