### PR TITLE
Add support for conda environment.

### DIFF
--- a/start_jupyter_cm/windows.py
+++ b/start_jupyter_cm/windows.py
@@ -61,6 +61,7 @@ def add_jupyter_here():
              'notebook': os.path.join(logo_path, 'jupyter.ico'),
              'lab': os.path.join(logo_path, 'jupyter.ico')}
     for env in ('qtconsole', 'notebook', 'lab'):
+        environment_name = ""
         if "WINPYDIR" in os.environ:
             # Calling from WinPython
             # Paths are relative, so we have to set the env first
@@ -68,6 +69,19 @@ def add_jupyter_here():
                                   WPSCRIPTS_FOLDER,
                                   "env.bat")
             script += " & jupyter-%s" % env
+        elif "CONDA_EXE" in os.environ:
+            # Calling from a conda environment, call activation script before
+            # executing script.
+            script = '%windir%\system32\cmd.exe "/K" '
+            script += os.path.join(os.path.split(os.environ["CONDA_EXE"])[0],
+                                  "activate.bat")
+            if ("CONDA_DEFAULT_ENV" in os.environ and 
+                os.environ["CONDA_DEFAULT_ENV"] != "base"):
+                # Add environment name if necessary
+                environment_name = os.environ["CONDA_DEFAULT_ENV"]
+                script += " " + environment_name
+                environment_name = " (%s)"%environment_name
+            script += " & jupyter-%s.exe" % env
         else:
             script = os.path.join(
                 sys.prefix, 'Scripts', "jupyter-%s.exe" % env)
@@ -84,8 +98,8 @@ def add_jupyter_here():
             "",
             0,
             winreg.REG_SZ,
-            "Jupyter %s here" %
-            env)
+            "Jupyter %s here%s" %(
+                    env, environment_name))
         winreg.SetValueEx(
             key,
             'Icon',
@@ -114,8 +128,8 @@ def add_jupyter_here():
             "",
             0,
             winreg.REG_SZ,
-            "Jupyter %s here" %
-            env)
+            "Jupyter %s here%s" %(
+                    env, environment_name))
         winreg.SetValueEx(
             key,
             'Icon',


### PR DESCRIPTION
Call activation script before calling command to make sure the environment is correctly activated. If installed from a conda environment other that "base" it will add the environment name in braket in the name of the shortcut.