### PR TITLE
Merge add/remove script into a new ``start_jupyter_cm`` script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+2.0.0
+-----
+* Merge installation and removal command into one single commands
+  ``start_jupyter_cm`` that takes a ``--remove`` argument.
+
 1.4.0
 -----
 * Add support for conda environment on linux.

--- a/README.rst
+++ b/README.rst
@@ -79,13 +79,13 @@ After installation, enable the context menu entries from a terminal as follows:
 
 .. code:: bash
 
-    $ jupyter_context-menu_add
+    $ start_jupyter_cm
 
 To remove the context menu entries execute the following in a terminal:
 
 .. code::
 
-    $ jupyter_context-menu_remove
+    $ start_jupyter_cm --remove
 
 To uninstall the package:
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'jupyter_context-menu_add = start_jupyter_cm:_add',
-            'jupyter_context-menu_remove = start_jupyter_cm:_remove',
+            'start_jupyter_cm = start_jupyter_cm.command:_run',
         ], }
 )

--- a/start_jupyter_cm/__init__.py
+++ b/start_jupyter_cm/__init__.py
@@ -1,18 +1,8 @@
 import os
+import argparse
 
-__version__ = "1.4.1.dev"
-
-if os.name == "nt":
-    from start_jupyter_cm.windows import (add_jupyter_here,
-                                          remove_jupyter_here)
-else:
-    from start_jupyter_cm.gnome import (add_jupyter_here,
-                                        remove_jupyter_here)
+__version__ = "2.0.dev"
 
 
-def _add():
-    add_jupyter_here()
 
-
-def _remove():
-    remove_jupyter_here()
+    

--- a/start_jupyter_cm/__init__.py
+++ b/start_jupyter_cm/__init__.py
@@ -1,6 +1,3 @@
-import os
-import argparse
-
 __version__ = "2.0.dev"
 
 

--- a/start_jupyter_cm/command.py
+++ b/start_jupyter_cm/command.py
@@ -1,0 +1,26 @@
+import argparse
+import os
+
+from start_jupyter_cm import __version__
+
+parser = argparse.ArgumentParser(
+    description='Add or remove context menu entries to start Jupyter applications in a given directory')
+parser.add_argument('--remove', action="store_true", help='remove the entries')
+parser.add_argument('--version', action='version', version='%(prog)s {version}'.format(version=__version__))
+
+args = parser.parse_args()
+
+
+def _run():
+    global args
+    if os.name == "nt":
+        from start_jupyter_cm.windows import (add_jupyter_here,
+                                            remove_jupyter_here)
+    else:
+        from start_jupyter_cm.gnome import (add_jupyter_here,
+                                            remove_jupyter_here)
+
+    if args.remove:
+        remove_jupyter_here()
+    else:
+        add_jupyter_here()


### PR DESCRIPTION
Change the current syntax to add:

```bash
jupyter_context-menu_add
```
and remove


```bash
jupyter_context-menu_remove
```
the context menu entries to

```bash
start_jupyter_cm
```
and 

```bash
start_jupyter_cm --remove
```

Note that this bumps the version number to 2.0 since it changes the API.