### PR TITLE
Changed path to python for gnome running scripts.

### DIFF
--- a/start_jupyter_cm/gnome.py
+++ b/start_jupyter_cm/gnome.py
@@ -13,7 +13,7 @@ CONDA_ENV_LABEL = get_environment_label()
 
 
 script = \
-    """#!%s/python
+    """#!%s
 
 import sys
 import os.path
@@ -45,7 +45,7 @@ def add_jupyter_here():
              'notebook': os.path.join(logo_path, 'jupyter.png'),
              'lab': os.path.join(logo_path, 'jupyter.png')}
 
-    path_python,filename = os.path.split(shutil.which("python"))
+    python_exec = shutil.which("python")
 
     for terminal in ["qtconsole", "notebook", "lab"]:
         script_path = os.path.join(SPATH, "Jupyter %s here%s" % (
@@ -53,7 +53,7 @@ def add_jupyter_here():
         if (not os.path.exists(script_path) and
             shutil.which("jupyter-%s" % terminal)):
             with open(script_path, "w") as f:
-                f.write(script % (path_python, PATH, terminal, PATH, terminal))
+                f.write(script % (python_exec, PATH, terminal, PATH, terminal))
             st = os.stat(script_path)
             os.chmod(script_path, st.st_mode | stat.S_IEXEC)
             call(['gio', 'set', '-t', 'string', '%s' % script_path,

--- a/start_jupyter_cm/gnome.py
+++ b/start_jupyter_cm/gnome.py
@@ -52,16 +52,8 @@ def add_jupyter_here():
                 terminal, CONDA_ENV_LABEL))
         if (not os.path.exists(script_path) and
             shutil.which("jupyter-%s" % terminal)):
-            SYSPATH,filename = os.path.split(shutil.which("jupyter-%s" % terminal))
-            if (SYSPATH == PATH):
-                path_exec = PATH
-            else:
-                print("        NOTE: jupyter-%s lies outside env directory, using this path instead:" % terminal)
-                print("        %s" % SYSPATH)
-                path_exec = SYSPATH
- 
             with open(script_path, "w") as f:
-                f.write(script % (path_python, path_exec, terminal, path_exec, terminal))
+                f.write(script % (path_python, PATH, terminal, PATH, terminal))
             st = os.stat(script_path)
             os.chmod(script_path, st.st_mode | stat.S_IEXEC)
             call(['gio', 'set', '-t', 'string', '%s' % script_path,

--- a/start_jupyter_cm/gnome.py
+++ b/start_jupyter_cm/gnome.py
@@ -13,7 +13,7 @@ CONDA_ENV_LABEL = get_environment_label()
 
 
 script = \
-    """#!/usr/bin/python
+    """#!%s/python
 
 import sys
 import os.path
@@ -45,13 +45,23 @@ def add_jupyter_here():
              'notebook': os.path.join(logo_path, 'jupyter.png'),
              'lab': os.path.join(logo_path, 'jupyter.png')}
 
+    path_python,filename = os.path.split(shutil.which("python"))
+
     for terminal in ["qtconsole", "notebook", "lab"]:
         script_path = os.path.join(SPATH, "Jupyter %s here%s" % (
                 terminal, CONDA_ENV_LABEL))
         if (not os.path.exists(script_path) and
             shutil.which("jupyter-%s" % terminal)):
+            SYSPATH,filename = os.path.split(shutil.which("jupyter-%s" % terminal))
+            if (SYSPATH == PATH):
+                path_exec = PATH
+            else:
+                print("        NOTE: jupyter-%s lies outside env directory, using this path instead:" % terminal)
+                print("        %s" % SYSPATH)
+                path_exec = SYSPATH
+ 
             with open(script_path, "w") as f:
-                f.write(script % (PATH, terminal, PATH, terminal))
+                f.write(script % (path_python, path_exec, terminal, path_exec, terminal))
             st = os.stat(script_path)
             os.chmod(script_path, st.st_mode | stat.S_IEXEC)
             call(['gio', 'set', '-t', 'string', '%s' % script_path,


### PR DESCRIPTION
I´ve removed the hardcoded dependence on /usr/bin/python.
Instead the gnome scripts will use the conda python executable.

Also, the checks for the path to jupyter that were written for the
macOS version have been added here too.