### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
       - name: Get version (on tag)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ----------------------
 
 * Add support for python 3.10 and drop python 3.6
+* Pin third party GitHub actions to SHA and update GitHub actions
 
 2.3.1
 -----


### PR DESCRIPTION
- Switch deprecation official github action to softprops/action-gh-release
- Pin third party GitHub actions